### PR TITLE
Better support for non-blocking IO

### DIFF
--- a/lib/postgresql.mli
+++ b/lib/postgresql.mli
@@ -380,6 +380,11 @@ type polling_status =
   | Polling_writing
   | Polling_ok
 
+(** Result of a call to flush on nonblocking connections. *)
+type flush_status =
+  | Successful
+  | Data_left_to_send
+
 (** Record of connection options *)
 type conninfo_option =
   {
@@ -526,6 +531,7 @@ object
       @raise Error if there is a connection error.
   *)
 
+  method server_version : int * int * int (* major, minor, revision *)
 
   (** Commands and Queries *)
 
@@ -801,7 +807,7 @@ object
       @raise Error if there is a connection error.
   *)
 
-  method flush : unit
+  method flush : flush_status
   (** [flush] attempts to flush any data queued to the backend.
 
       @raise Error if there is a connection error.

--- a/lib/postgresql_stubs.c
+++ b/lib/postgresql_stubs.c
@@ -369,7 +369,7 @@ conn_info(PQoptions, make_string)
 noalloc_conn_info(PQstatus, Val_int)
 conn_info(PQerrorMessage, make_string)
 noalloc_conn_info(PQbackendPID, Val_int)
-
+noalloc_conn_info(PQserverVersion, Val_int)
 
 /* Command Execution Functions */
 


### PR DESCRIPTION
The goal of the patch is to enable the use of non-blocking
connections, to make async integration easier.  To that end, we made
the following changes:

- For putline, putnbytes and endcopy, don't throw exceptions on
  non-blocking connections.

- Return meaningful status code from flush

Also, we added a binding for the server_version call.

Written by Max Wolter