### PR TITLE
Add ftype_oid, paramtype_oid methods

### DIFF
--- a/lib/postgresql.ml
+++ b/lib/postgresql.ml
@@ -567,9 +567,17 @@ object
     check_field field;
     ftype_of_oid (Stub.ftype res field)
 
+  method ftype_oid field =
+    check_field field;
+    Stub.ftype res field
+
   method paramtype field =
     check_param field;
     ftype_of_oid (Stub.paramtype res field)
+
+  method paramtype_oid field =
+    check_param field;
+    Stub.paramtype res field
 
   method fmod field = check_field field; Stub.fmod res field
   method fsize field = check_field field; Stub.fsize res field

--- a/lib/postgresql.mli
+++ b/lib/postgresql.mli
@@ -261,6 +261,12 @@ class type result = object
       @raise Error if field out of range.
   *)
 
+  method ftype_oid : int -> oid
+  (** [#ftype n] @return the oid of the [n]th field.
+
+      @raise Error if field out of range.
+  *)
+
   method paramtype : int -> ftype
   (** [#paramtype n] @return the datatype of the indicated statement
       parameter.  Parameter numbers start at 0.  This function is
@@ -268,6 +274,15 @@ class type result = object
       For other types of queries it will return zero.
 
       @raise Oid if there was no corresponding ftype for the internal [oid].
+      @raise Error if field out of range.
+  *)
+
+  method paramtype_oid : int -> oid
+  (** [#paramtype n] @return the oid of the indicated statement
+      parameter.  Parameter numbers start at 0.  This function is
+      only useful when inspecting the result of [#describe_prepared].
+      For other types of queries it will return zero.
+
       @raise Error if field out of range.
   *)
 


### PR DESCRIPTION
Currently, many array oids (e.g. `INT32ARRAYOID`) are missing in `ftype` definition. I would like to add such missing oids, but for workaround, it could be useful if there were methods something like `ftype_oid`. I am not sure that the name `ftype_oid` is preferable. Maybe should be `foid` and `paramoid`?