### PR TITLE
Register Error exception printer

### DIFF
--- a/lib/postgresql.ml
+++ b/lib/postgresql.ml
@@ -325,6 +325,11 @@ let string_of_error = function
 
 exception Error of error
 
+let () =
+  Printexc.register_printer
+    (function
+      | Error e -> Some (Printf.sprintf "Postgresql.Error(%S)" (string_of_error e))
+      | _ -> None)
 
 module Stub = struct
   (* Database Connection Functions *)


### PR DESCRIPTION
This makes the `Error` exception will be pretty-printed.

Before:

    Postgresql.Error(_)

After:

    Postgresql.Error("Connection failure: SSL SYSCALL error: EOF detected\n")
