### PR TITLE
Update notification to include "extra" parameter

### DIFF
--- a/examples/prompt.ml
+++ b/examples/prompt.ml
@@ -49,8 +49,8 @@ let rec dump_res conn =
 
 let rec dump_notification conn =
   match conn#notifies with
-  | Some (msg, pid) ->
-      printf "Notication from backend %i: [%s]\n" pid msg;
+  | Some (msg, pid, extra) ->
+      printf "Notication from backend %i: [%s] [%s]\n" pid msg extra;
       flush stdout;
       dump_notification conn
   | None -> ()

--- a/examples/prompt_gtk.ml
+++ b/examples/prompt_gtk.ml
@@ -147,8 +147,8 @@ let main () =
 
   let rec dump_notification () =
     match conn#notifies with
-    | Some (msg, pid) ->
-        let _ = clist#append [string_of_int pid; msg] in
+    | Some (msg, pid, extra) ->
+        let _ = clist#append [string_of_int pid; msg; extra] in
         window#show ();
         dump_notification ()
     | None -> () in

--- a/lib/postgresql.ml
+++ b/lib/postgresql.ml
@@ -452,7 +452,7 @@ module Stub = struct
 
   (* Asynchronous Notification *)
 
-  external notifies : connection -> (string * int) option = "PQnotifies_stub"
+  external notifies : connection -> (string * int * string) option = "PQnotifies_stub"
 
 
   (* Functions Associated with the COPY Command *)

--- a/lib/postgresql.mli
+++ b/lib/postgresql.mli
@@ -469,9 +469,10 @@ object
   (** Asynchronous Notification *)
 
   method notifies : (string * int * string) option
-  (** [#notifies] @return [Some (name, pid)] if available ([None]
+  (** [#notifies] @return [Some (name, pid, extra)] if available ([None]
       otherwise), where [name] is the name the of relation containing
-      data, [pid] the process id of the backend.
+      data, [pid] the process id of the backend, and [extra] is any payload
+      data associated with the notification (empty it not provided).
 
       @raise Error if there is a connection error.
   *)

--- a/lib/postgresql.mli
+++ b/lib/postgresql.mli
@@ -468,7 +468,7 @@ object
 
   (** Asynchronous Notification *)
 
-  method notifies : (string * int) option
+  method notifies : (string * int * string) option
   (** [#notifies] @return [Some (name, pid)] if available ([None]
       otherwise), where [name] is the name the of relation containing
       data, [pid] the process id of the backend.

--- a/lib/postgresql_stubs.c
+++ b/lib/postgresql_stubs.c
@@ -1006,14 +1006,17 @@ CAMLprim value PQnotifies_stub(value v_conn)
 {
   CAMLparam1(v_conn);
   CAMLlocal1(v_str);
+  CAMLlocal1(v_extra);
   PGnotify *noti = PQnotifies(get_conn(v_conn));
 
   if (noti) {
     value v_pair;
     v_str = make_string(noti->relname);
-    v_pair = caml_alloc_small(2, 0);
+    v_pair = caml_alloc_small(3, 0);
+    v_extra = make_string(noti->extra);
     Field(v_pair, 0) = v_str;
     Field(v_pair, 1) = Val_int(noti->be_pid);
+    Field(v_pair, 2) = v_extra;
     PQfreemem(noti);
     CAMLreturn(make_some(v_pair));
   }


### PR DESCRIPTION
Since PostgreSQL 9.0 Listen/Notify is able to carry a small payload associated with the notification.  This patch implements that.

I have tested examples/prompt and it works as expected.

> ./prompt.native 'postgresql://jonathan@localhost:5432/testdb'
[snip]
> listen foobar;
Command ok [LISTEN]
> Notication from backend 10148: [foobar] []    # select pg_notify('foobar', null);
Notication from backend 10148: [foobar] [42]   # select pg_notify('foobar', '42');