### PR TITLE
Fix broken notification code in gtk example

### DIFF
--- a/examples/prompt_gtk.ml
+++ b/examples/prompt_gtk.ml
@@ -147,8 +147,8 @@ let main () =
 
   let rec dump_notification () =
     match conn#notifies with
-    | Some (msg, pid, extra) ->
-        let _ = clist#append [string_of_int pid; msg; extra] in
+    | Some { Notification.name; pid; extra } ->
+        let _ = clist#append [string_of_int pid; name; extra] in
         window#show ();
         dump_notification ()
     | None -> () in


### PR DESCRIPTION
I just tried to bring in the new version from opam and it failed to compile (since I already have lablgtk installed).

The example now compiles (but doesn't actually run on my machine).

I think a point release might be needed.

Thanks!