### PR TITLE
Add put_copy_data, put_copy_end, and get_copy_data.

### DIFF
--- a/examples/copy.ml
+++ b/examples/copy.ml
@@ -1,0 +1,62 @@
+open Postgresql
+open Printf
+
+let _ =
+  if Array.length Sys.argv <> 2 then (
+    Printf.printf "\
+      Usage:  copy conninfo\n\
+      Connect to PostgreSQL with [conninfo] (e.g. \"host=localhost\"),\n";
+    exit 1)
+
+let create_sql = "\
+  CREATE TEMPORARY TABLE pgo_copy_test (\
+    id SERIAL PRIMARY KEY, \
+    name text UNIQUE NOT NULL, \
+    x integer NOT NULL\
+  )"
+
+let populate ?error_msg (c : connection) =
+  let _ = c#exec ~expect:[Copy_in] "COPY pgo_copy_test (name, x) FROM STDIN" in
+  for i = 0 to 9999 do
+    match c#put_copy_data (sprintf "c%d\t%d\n" i i) with
+    | Put_copy_error | Put_copy_not_queued -> assert false
+    | Put_copy_queued -> ()
+  done;
+  begin match c#put_copy_end ?error_msg () with
+  | Put_copy_error | Put_copy_not_queued -> assert false
+  | Put_copy_queued -> ()
+  end;
+  match c#get_result with
+  | None -> assert false
+  | Some result ->
+    begin match error_msg, result#status with
+    | None, Command_ok -> ()
+    | Some _msg, Fatal_error -> ()
+    | _ -> assert false
+    end
+
+let verify (c : connection) =
+  let _ =
+    c#exec ~expect:[Copy_out] "COPY pgo_copy_test (id, name, x) TO STDOUT" in
+  for i = 0 to 9999 do
+    match c#get_copy_data () with
+    | Get_copy_data data ->
+      assert (data = sprintf "%d\tc%d\t%d\n" (i + 1) i i)
+    | Get_copy_wait | Get_copy_end | Get_copy_error -> assert false
+  done;
+  match c#get_copy_data () with
+  | Get_copy_end -> ()
+  | _ -> assert false
+
+let main () =
+  let c = new connection ~conninfo:Sys.argv.(1) () in
+  let _ = c#exec ~expect:[Command_ok] create_sql in
+  populate c;
+  populate c ~error_msg:"test failure";
+  verify c;
+  c#finish
+
+let () =
+  try main () with
+  | Error e -> prerr_endline (string_of_error e)
+  | e -> prerr_endline (Printexc.to_string e)

--- a/examples/dune
+++ b/examples/dune
@@ -1,4 +1,4 @@
 (executables
-  (names async binary cursor dump populate prompt test_lo)
+  (names async binary copy cursor dump populate prompt test_lo)
   (libraries postgresql)
 )


### PR DESCRIPTION
These were introduced in libpq 7.4, obsoleting the other functions
dealing with COPY data.

The stubs could use a second pair of eyes, as I seldom write bindings.  Also, let me know if you prefer some adjustments to the API, like exceptions instead of the last variant cases, or adding a separate `get_copy_data_async` in place of the `async` argument.
