### PR TITLE
PQisBusy_stub is releasing master lock, so it can't be "noalloc"

### DIFF
--- a/src/postgresql.ml
+++ b/src/postgresql.ml
@@ -498,7 +498,7 @@ module Stub = struct
   external consume_input : connection -> (int [@untagged])
     = "PQconsumeInput_stub_bc" "PQconsumeInput_stub" [@@noalloc]
 
-  external is_busy : connection -> bool = "PQisBusy_stub" [@@noalloc]
+  external is_busy : connection -> bool = "PQisBusy_stub"
 
   external flush : connection -> (int [@untagged])
     = "PQflush_stub_bc" "PQflush_stub" [@@noalloc]


### PR DESCRIPTION
According to section 20.11.2 of
https://caml.inria.fr/pub/docs/manual-ocaml/intfc.html,
functions marked [@@noalloc] can not release master lock. Since 4.6.1,
PQisBusy_stub is releasing master lock, so it can't be "noalloc"
anymore.

Having it as "noalloc" causes segfaults (I don't have a small
reproducible example, but I think you can see how it could happen).