### PR TITLE
Port the config discovery script to pkg-config

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -1,3 +1,5 @@
+module C = Configurator.V1
+
 open Printf
 
 let find_number ~pos str =
@@ -21,43 +23,65 @@ let find_number ~pos str =
   let number_lst, next = loop ~pos in
   String.concat "" number_lst, next
 
-let () =
-  let module C = Configurator.V1 in
-  C.main ~name:"postgresql" (fun _c ->
-    let cmd = "pg_config --includedir --libdir --version" in
-    let ic =
-      try Unix.open_process_in cmd
-      with exc -> eprintf "could not open pg_config, cmd: '%s'" cmd; raise exc
+let pg_major_minor ic =
+  let line = input_line ic in
+  let print_fail () =
+    eprintf "Unable to find versions from line '%s'" line
+  in
+  let exit_fail () = print_fail (); exit 1 in
+  try
+    let first_space = String.index line ' ' in
+    let major, next = find_number ~pos:first_space line in
+    let minor =
+      (* Can also handle release candidates *)
+      let c = line.[next] in
+      if c = '.' then fst (find_number ~pos:next line)
+      else if c <> 'r' || line.[next + 1] <> 'c' then exit_fail ()
+      else "0"
     in
-    Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
-      let pgsql_includedir = "-I" ^ input_line ic in
-      let pgsql_libdir = "-L" ^ input_line ic in
-      let major, minor =
-        let line = input_line ic in
-        let print_fail () =
-          eprintf "Unable to find versions from line '%s', cmd: '%s'" line cmd
-        in
-        let exit_fail () = print_fail (); exit 1 in
-        try
-          let first_space = String.index line ' ' in
-          let major, next = find_number ~pos:first_space line in
-          let minor =
-            (* Can also handle release candidates *)
-            let c = line.[next] in
-            if c = '.' then fst (find_number ~pos:next line)
-            else if c <> 'r' || line.[next + 1] <> 'c' then exit_fail ()
-            else "0"
-          in
-          if major = "" || minor = "" then exit_fail ()
-          else
-            "-DPG_OCAML_MAJOR_VERSION=" ^ major,
-            "-DPG_OCAML_MINOR_VERSION=" ^ minor
-        with exn -> print_fail (); raise exn
+    if major = "" || minor = "" then exit_fail ()
+    else
+      "-DPG_OCAML_MAJOR_VERSION=" ^ major,
+      "-DPG_OCAML_MINOR_VERSION=" ^ minor
+  with exn -> print_fail (); raise exn
+
+let major_minor_from_pgconfig () =
+  let cmd = "pg_config --version" in
+  let ic =
+    try Unix.open_process_in cmd
+    with exc -> eprintf "could not open pg_config, cmd: '%s'" cmd; raise exc
+  in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () -> pg_major_minor ic)
+
+let from_pgconfig () =
+  let cmd = "pg_config --includedir --libdir --version" in
+  let ic =
+    try Unix.open_process_in cmd
+    with exc -> eprintf "could not open pg_config, cmd: '%s'" cmd; raise exc
+  in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+    let pgsql_includedir = "-I" ^ input_line ic in
+    let pgsql_libdir = "-L" ^ input_line ic in
+    let major, minor = pg_major_minor ic in
+    { C.Pkg_config.cflags = [pgsql_includedir; major; minor]
+    ; libs = [pgsql_libdir; "-lpq"]
+    })
+
+let () =
+  C.main ~name:"postgresql" (fun c ->
+      let conf =
+        match C.Pkg_config.get c with
+        | Some pc ->
+         begin match
+           C.Pkg_config.query pc ~package:"libpq"
+         with
+         | Some conf ->
+           let major, minor = major_minor_from_pgconfig () in
+           { conf with
+             C.Pkg_config.cflags = major :: minor :: conf.cflags }
+         | None -> { C.Pkg_config.cflags = []; libs = [] }
+         end
+        | None -> from_pgconfig ()
       in
-      let conf = {
-        C.Pkg_config.
-        cflags = [pgsql_includedir; major; minor];
-        libs = [pgsql_libdir; "-lpq"];
-      } in
       C.Flags.write_sexp "c_flags.sexp" conf.cflags;
-      C.Flags.write_sexp "c_library_flags.sexp" conf.libs))
+      C.Flags.write_sexp "c_library_flags.sexp" conf.libs)


### PR DESCRIPTION
- PostgreSQL installations also add `pkg-config` configuration files.
- In cross-compilation scenarios, calling out to `pg_config` will list the wrong `--libdir`
- This change uses `pkg-config` to find the C include & library flags for `libpq`
  - I've kept a fallback to the current `pg_config`-based implementation to avoid errors in cases that users don't have `pkg-config` in their `$PATH`.

also slightly related to https://github.com/ocaml/dune/issues/1492#issuecomment-1236421326