### PR TITLE
use Unix.file_descr for sockect

### DIFF
--- a/src/postgresql.ml
+++ b/src/postgresql.ml
@@ -1145,7 +1145,7 @@ object (self)
   method socket =
     wrap_conn (fun conn ->
       let s = Stub.socket conn in
-      if s = -1 then signal_error conn else s)
+      if s = -1 then signal_error conn else (Obj.magic s : Unix.file_descr))
 
   method request_cancel = request_cancel ()
 

--- a/src/postgresql.ml
+++ b/src/postgresql.ml
@@ -507,6 +507,8 @@ module Stub = struct
   external flush : connection -> (int [@untagged])
     = "PQflush_stub_bc" "PQflush_stub" [@@noalloc]
 
+  external filedescr_of_fd : int -> Unix.file_descr = "win_handle_fd"
+
   external socket : connection -> (int [@untagged])
     = "PQsocket_stub_bc" "PQsocket_stub" [@@noalloc]
 
@@ -1145,7 +1147,7 @@ object (self)
   method socket =
     wrap_conn (fun conn ->
       let s = Stub.socket conn in
-      if s = -1 then signal_error conn else (Obj.magic s : Unix.file_descr))
+      if s = -1 then signal_error conn else Stub.filedescr_of_fd s)
 
   method request_cancel = request_cancel ()
 

--- a/src/postgresql.mli
+++ b/src/postgresql.mli
@@ -1022,7 +1022,7 @@ object
       @raise Error if there is a connection error.
   *)
 
-  method socket : int
+  method socket : Unix.file_descr
   (** [socket] obtains the file descriptor for the backend connection
       socket as an integer.
 


### PR DESCRIPTION
The socket method is unusable with type int, for instance with select in async mode.

This solves the problem. I think there is no way in Stdlib to convert int to Unix.file_descr so I used 
the same code as OCaml uses for stdin and alike.

I did not do it in the C.stub because of the comparison with -1 and to keep the [@untagged] flag.

Should be tested on windows because there file_descr are not int. But if there is a problem, it should 
be there with or without this patch, PQsocket does return int on both platforms. So the conversion should actually
make it better on windows.