### PR TITLE
discover: read `$PKG_CONFIG` to fix cross-compilation

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -55,17 +55,34 @@ let major_minor_from_pgconfig () =
   in
   Fun.protect ~finally:(fun () -> close_in ic) (fun () -> pg_major_minor ic)
 
-let major_minor_from_pkg_config () =
-  let ic = Unix.open_process_in "pkg-config --modversion libpq" in
-  Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
-  let version_line = input_line ic in
-  (* Typically something like "14.1" *)
-  match String.split_on_char '.' version_line with
-  | major :: minor :: _ ->
-      ("-DPG_OCAML_MAJOR_VERSION=" ^ major, "-DPG_OCAML_MINOR_VERSION=" ^ minor)
-  | _ ->
-      eprintf "Unable to parse libpq version: %s" version_line;
-      exit 1
+let major_minor_from_pkg_config =
+  let pkg_config_prefix () =
+    let pkg_config_args =
+      match Sys.getenv "PKG_CONFIG_ARGN" with
+      | s -> String.split_on_char ' ' s
+      | exception Not_found -> []
+    in
+    let bin =
+      match Sys.getenv "PKG_CONFIG" with
+      | s -> s
+      | exception Not_found -> "pkg-config"
+    in
+    Format.asprintf "%s %s " bin (String.concat " " pkg_config_args)
+  in
+  fun () ->
+    let ic =
+      Unix.open_process_in (pkg_config_prefix () ^ " --modversion libpq")
+    in
+    Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
+    let version_line = input_line ic in
+    (* Typically something like "14.1" *)
+    match String.split_on_char '.' version_line with
+    | major :: minor :: _ ->
+        ( "-DPG_OCAML_MAJOR_VERSION=" ^ major,
+          "-DPG_OCAML_MINOR_VERSION=" ^ minor )
+    | _ ->
+        eprintf "Unable to parse libpq version: %s" version_line;
+        exit 1
 
 let from_pgconfig () =
   let cmd = "pg_config --includedir --libdir --version" in


### PR DESCRIPTION
- copies the logic from dune (https://github.com/ocaml/dune/blob/bca9e656b61f7d2b827016b7fd9b1a682c690a7b/otherlibs/configurator/src/v1.ml#L660)
- tested in https://github.com/nix-ocaml/nix-overlays/pull/1815 (check the first commit failing, and this patch fixing it.)