### PR TITLE
Parametrisation by the Mutex module + remove use for condition

### DIFF
--- a/lib/postgresql.mli
+++ b/lib/postgresql.mli
@@ -487,30 +487,8 @@ val conndefaults : unit -> conninfo_option array
       usable.
 
     @raise Error if there is a connection failure. *)
-class connection :
-  ?host:string ->
-  (* Default: none *)
-  ?hostaddr:string ->
-  (* Default: none *)
-  ?port:string ->
-  (* Default: none *)
-  ?dbname:string ->
-  (* Default: none *)
-  ?user:string ->
-  (* Default: none *)
-  ?password:string ->
-  (* Default: none *)
-  ?options:string ->
-  (* Default: none *)
-  ?tty:string ->
-  (* Default: none *)
-  ?requiressl:string ->
-  (* Default: none *)
-  ?conninfo:string ->
-  (* Default: none *)
-  ?startonly:bool ->
-  (* Default: false *)
-  unit ->
+
+class type connection_class =
 object
   (* Main routines *)
 
@@ -1078,4 +1056,63 @@ object
 
       @param pos default = 0
       @param len default = String.length str - pos *)
+end
+
+class connection : ?host:string ->
+  (* Default: none *)
+  ?hostaddr:string ->
+  (* Default: none *)
+  ?port:string ->
+  (* Default: none *)
+  ?dbname:string ->
+  (* Default: none *)
+  ?user:string ->
+  (* Default: none *)
+  ?password:string ->
+  (* Default: none *)
+  ?options:string ->
+  (* Default: none *)
+  ?tty:string ->
+  (* Default: none *)
+  ?requiressl:string ->
+  (* Default: none *)
+  ?conninfo:string ->
+  (* Default: none *)
+  ?startonly:bool ->
+  (* Default: false *)
+  unit -> connection_class
+
+(** Type of a mutex module *)
+module type Mutex = sig
+  type t
+  val create : unit -> t
+  val lock : t -> unit
+  val unlock : t -> unit
+end
+
+(** Connection parametrized by the type of mutex used *)
+module Connection(_:Mutex) : sig
+  class connection : ?host:string ->
+  (* Default: none *)
+  ?hostaddr:string ->
+  (* Default: none *)
+  ?port:string ->
+  (* Default: none *)
+  ?dbname:string ->
+  (* Default: none *)
+  ?user:string ->
+  (* Default: none *)
+  ?password:string ->
+  (* Default: none *)
+  ?options:string ->
+  (* Default: none *)
+  ?tty:string ->
+  (* Default: none *)
+  ?requiressl:string ->
+  (* Default: none *)
+  ?conninfo:string ->
+  (* Default: none *)
+  ?startonly:bool ->
+  (* Default: false *)
+  unit -> connection_class
 end

--- a/lib/postgresql.mli
+++ b/lib/postgresql.mli
@@ -488,8 +488,7 @@ val conndefaults : unit -> conninfo_option array
 
     @raise Error if there is a connection failure. *)
 
-class type connection_class =
-object
+class type connection_class = object
   (* Main routines *)
 
   method finish : unit
@@ -1058,7 +1057,8 @@ object
       @param len default = String.length str - pos *)
 end
 
-class connection : ?host:string ->
+class connection :
+  ?host:string ->
   (* Default: none *)
   ?hostaddr:string ->
   (* Default: none *)
@@ -1080,39 +1080,43 @@ class connection : ?host:string ->
   (* Default: none *)
   ?startonly:bool ->
   (* Default: false *)
-  unit -> connection_class
+  unit ->
+  connection_class
 
 (** Type of a mutex module *)
 module type Mutex = sig
   type t
+
   val create : unit -> t
   val lock : t -> unit
   val unlock : t -> unit
 end
 
 (** Connection parametrized by the type of mutex used *)
-module Connection(_:Mutex) : sig
-  class connection : ?host:string ->
-  (* Default: none *)
-  ?hostaddr:string ->
-  (* Default: none *)
-  ?port:string ->
-  (* Default: none *)
-  ?dbname:string ->
-  (* Default: none *)
-  ?user:string ->
-  (* Default: none *)
-  ?password:string ->
-  (* Default: none *)
-  ?options:string ->
-  (* Default: none *)
-  ?tty:string ->
-  (* Default: none *)
-  ?requiressl:string ->
-  (* Default: none *)
-  ?conninfo:string ->
-  (* Default: none *)
-  ?startonly:bool ->
-  (* Default: false *)
-  unit -> connection_class
+module Connection (_ : Mutex) : sig
+  class connection :
+    ?host:string ->
+    (* Default: none *)
+    ?hostaddr:string ->
+    (* Default: none *)
+    ?port:string ->
+    (* Default: none *)
+    ?dbname:string ->
+    (* Default: none *)
+    ?user:string ->
+    (* Default: none *)
+    ?password:string ->
+    (* Default: none *)
+    ?options:string ->
+    (* Default: none *)
+    ?tty:string ->
+    (* Default: none *)
+    ?requiressl:string ->
+    (* Default: none *)
+    ?conninfo:string ->
+    (* Default: none *)
+    ?startonly:bool ->
+    (* Default: false *)
+    unit ->
+    connection_class
 end


### PR DESCRIPTION
I think (might be wrong) that the condition and connection state `Used was useless and that protecting all call by a mutex seems enough to me. This PR removes the condition and replace the connection state by a boolean. It also offers a functor parametrized by the mutex module.

Remark : if you can avoid the fact that I had to copy the class type connection both in .ml (without comments) and in .mli,
I would be happy. Moving all type defs in sig.ml is not so nice for the generated documentation.

Remark : In asynch mode, it could have been useful to have a Used state, but in the code before this PR send_query or send_query_prepare got the mode back to `Free. Moreover, there is no way to know when the connection is free, that is when the user does not need the connection result anymore.
