### PR TITLE
getvalue and alike returns Postgresql.null for NULL values

### DIFF
--- a/lib/postgresql.mli
+++ b/lib/postgresql.mli
@@ -211,7 +211,13 @@ val invalid_oid : oid
 val null : string
 (** [null] can be used as an element of the optional argument [parameters]
     passed to the [exec] or [send_query] method to indicate a NULL value. It is
-    an empty string, but not physically equal to [""]. *)
+    an empty string, but not physically equal to [""].
+
+    [null] is also returned by [getvalue] and [get_escaped_value], [gettuple],
+    ... for NULL values.
+
+    Remark: is you use NULL within array or other structured data, you will
+    have to handle NULL values according to postgresql documentation.  *)
 
 (** Class type of query results.
 

--- a/lib/postgresql_stubs.c
+++ b/lib/postgresql_stubs.c
@@ -796,6 +796,7 @@ CAMLprim value PQgetvalue_stub(value v_res, intnat tup_num, intnat field_num) {
   CAMLparam1(v_res);
   value v_str;
   PGresult *res = get_res(v_res);
+  if (PQgetisnull(res, tup_num, field_num)) CAMLreturn(*v_null_param);
   char *str = PQgetvalue(res, tup_num, field_num);
   if (PQfformat(res, field_num) == 0)
     v_str = make_string(str);
@@ -892,6 +893,7 @@ CAMLprim value PQgetescval_stub(value v_res, intnat tup_num, intnat field_num) {
   CAMLparam1(v_res);
   value v_str;
   PGresult *res = get_res(v_res);
+  if (PQgetisnull(res, tup_num, field_num)) CAMLreturn(*v_null_param);
   char *str = PQgetvalue(res, tup_num, field_num);
   if (PQfformat(res, field_num) == 0) {
     if (str == NULL || strlen(str) < 2 || !is_bytea_hex_protocol(str))


### PR DESCRIPTION
I got hard to track down bugs because Postgresql.null was not used consistently in both directions.
It was used in the direction Caml -> Postgres only. As postgresql.null = "" this should not break any existing code, but could allow simplifying (or even fix ;-) some existing code. 

Because, PQgetisnull is called from C at each getvalue, it could slow down code that do not use a lot NULL values, but speedup code that use them a lot by if one removes the need to call Postgress.getisnull.
