### PR TITLE
Need to use PQsendQueryParams, not PQsendQuery, to enable binary_result

### DIFF
--- a/lib/postgresql_stubs.c
+++ b/lib/postgresql_stubs.c
@@ -961,7 +961,7 @@ CAMLprim intnat PQsendQueryParams_stub(value v_conn, value v_query,
   intnat res;
   copy_binary_params(v_params, v_binary_params, nparams, &formats, &lengths);
   bool binary_result = Bool_val(v_binary_result);
-  res = (nparams == 0)
+  res = (nparams == 0 && !binary_result)
             ? PQsendQuery(conn, query)
             : PQsendQueryParams(conn, query, nparams, param_types, params,
                                 lengths, formats, binary_result);


### PR DESCRIPTION
The title says it all as well :-)

Cf https://github.com/mmottl/postgresql-ocaml/pull/52#issuecomment-3328832709