### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,7 @@
 ---
 name: pre-commit
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mmottl/postgresql-ocaml/security/code-scanning/10](https://github.com/mmottl/postgresql-ocaml/security/code-scanning/10)

To fix the problem, you need to add a `permissions` block either at the root of the workflow file (top-level, below `name:` and before `jobs:`) or for the individual job (under `jobs.hooks`). Since there is only one job, adding it at the root is cleanest and ensures minimal privileges for all jobs that do not require elevated access. The recommended minimal block is `permissions: contents: read`, which grants only read access to repository contents. No steps in the workflow require write access, so this is sufficient. Edit `.github/workflows/pre-commit.yml` by inserting the following after the `name:` line (line 2).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
